### PR TITLE
Restful urls for STN flood events data

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,21 @@
 History
 =======
 
+0.15.1 (2023-07-27)
+-------------------
+Contributor: [Fernando Aristizabal](https://github.com/fernando-aristizabal)
+
+From release 0.15 onward, all minor versions of HyRiver packages
+will be pinned. This ensures that previous minor versions of HyRiver
+packages cannot be installed with later minor releases. For example,
+if you have ``pygeoogc==0.14.x`` installed, you cannot install
+``pygeoogc==0.15.x`` series. This is to ensure that the API is
+consistent across all minor versions.
+
+New Features
+~~~~~~~~~~~~
+- Added RESTfulURLs for STN Flood Event Data Retriever.
+
 0.15.0 (2023-05-07)
 -------------------
 From release 0.15 onward, all minor versions of HyRiver packages

--- a/pygeoogc/pygeoogc.py
+++ b/pygeoogc/pygeoogc.py
@@ -797,7 +797,7 @@ class RESTfulURLs(NamedTuple):
     )
     geoconnex: str = "https://reference.geoconnex.us"
     stnflood: str = "https://stn.wim.usgs.gov/STNServices/"
-    stnflood_dd: str = "https://stn.wim.usgs.gov/STNWeb/datadictionary/"
+    stnflood_dd: str = "https://stn.wim.usgs.gov/STNWeb/datadictionary/"#
 
 
 class WFSURLs(NamedTuple):

--- a/pygeoogc/pygeoogc.py
+++ b/pygeoogc/pygeoogc.py
@@ -796,6 +796,8 @@ class RESTfulURLs(NamedTuple):
         "https://index.nationalmap.gov/arcgis/rest/services/3DEPElevationIndex/MapServer"
     )
     geoconnex: str = "https://reference.geoconnex.us"
+    stnflood: str = "https://stn.wim.usgs.gov/STNServices/"
+    stnflood_dd: str = "https://stn.wim.usgs.gov/STNWeb/datadictionary/"
 
 
 class WFSURLs(NamedTuple):

--- a/pygeoogc/pygeoogc.py
+++ b/pygeoogc/pygeoogc.py
@@ -797,7 +797,7 @@ class RESTfulURLs(NamedTuple):
     )
     geoconnex: str = "https://reference.geoconnex.us"
     stnflood: str = "https://stn.wim.usgs.gov/STNServices/"
-    stnflood_dd: str = "https://stn.wim.usgs.gov/STNWeb/datadictionary/"#
+    stnflood_dd: str = "https://stn.wim.usgs.gov/STNWeb/datadictionary/"
 
 
 class WFSURLs(NamedTuple):


### PR DESCRIPTION
Added RestFUL URLs relevant to the STN flood events data retriever.

 - [X] No issues associated with this PR.
 - [X] 0 Tests added and `nox` passes with 1 failure: `FAILED tests/test_pygeoogc.py::test_stream - pygeoogc.exceptions.ServiceError: Service returned the following error message:`
 - [X] Passes `pre-commit run --all-files`
 - [X] Changes and the contributor name are documented in `HISTORY.rst`.
