### PR TITLE
FEMA Restful service urls

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,4 +11,4 @@ Contributors
 ------------
 
 * `Tim Cera <https://github.com/timcera>`__: :pull_ogc:`58`
-* `Fernando Aristizabal <https://github.com/fernando-aristizabal>`_
+* `Fernando Aristizabal <https://github.com/fernando-aristizabal>`__: :pull_ogc:`62`

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,3 +11,4 @@ Contributors
 ------------
 
 * `Tim Cera <https://github.com/timcera>`__: :pull_ogc:`58`
+* `Fernando Aristizabal <https://github.com/fernando-aristizabal>`_

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,21 @@
 History
 =======
 
+0.15.2 (2023-XX-XX)
+-------------------
+Contributor: [Fernando Aristizabal](https://github.com/fernando-aristizabal)
+
+From release 0.15 onward, all minor versions of HyRiver packages
+will be pinned. This ensures that previous minor versions of HyRiver
+packages cannot be installed with later minor releases. For example,
+if you have ``pygeoogc==0.14.x`` installed, you cannot install
+``pygeoogc==0.15.x`` series. This is to ensure that the API is
+consistent across all minor versions.
+
+New Features
+~~~~~~~~~~~~
+- Added RESTfulURLs for FEMA's National Flood Hazard Layer (NFHL) service.
+
 0.15.1 (2023-07-27)
 -------------------
 Contributor: [Fernando Aristizabal](https://github.com/fernando-aristizabal)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,8 +4,6 @@ History
 
 0.15.2 (2023-XX-XX)
 -------------------
-Contributor: [Fernando Aristizabal](https://github.com/fernando-aristizabal)
-
 From release 0.15 onward, all minor versions of HyRiver packages
 will be pinned. This ensures that previous minor versions of HyRiver
 packages cannot be installed with later minor releases. For example,
@@ -16,8 +14,8 @@ consistent across all minor versions.
 New Features
 ~~~~~~~~~~~~
 - Added RESTfulURLs for FEMA's National Flood Hazard Layer (NFHL) service.
+  Contributed by `Fernando Aristizabal <https://github.com/fernando-aristizabal>`__
 
-0.15.1 (2023-07-27)
 0.15.2 (2023-0X-XX)
 -------------------
 

--- a/pygeoogc/pygeoogc.py
+++ b/pygeoogc/pygeoogc.py
@@ -773,7 +773,12 @@ class RESTfulURLs(NamedTuple):
 
     daymet: str = "https://thredds.daac.ornl.gov/thredds/ncss/ornldaac"
     daymet_point: str = "https://daymet.ornl.gov/single-pixel/api/data"
-    fema: str = "https://hazards.fema.gov/gis/nfhl/rest/services/public/NFHL/MapServer"
+    fema_nfhl: str = "https://hazards.fema.gov/gis/nfhl/services/public/NFHL/MapServer"
+    fema_prelim_cslf: str = "https://hazards.fema.gov/gis/cslf/rest/services/Prelim_CSLF/MapServer"
+    fema_draft_cslf: str = "https://hazards.fema.gov/gis/cslf/rest/services/Draft_CSLF/MapServer"
+    fema_prelim_nfhl: str = "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Prelim_NFHL/MapServer"
+    fema_pending_nfhl: str = "https://hazards.fema.gov/gis/nfhl/rest/services/PrelimPending/Pending_NFHL/MapServer"
+    fema_draft_nfhl: str = "https://hazards.fema.gov/gis/nfhl/rest/services/AFHI/Draft_FIRM_DB/MapServer"
     fws: str = "https://www.fws.gov/wetlandsmapservice/rest/services"
     nldi: str = "https://labs.waterdata.usgs.gov/api/nldi"
     nwis: str = "https://waterservices.usgs.gov/nwis"


### PR DESCRIPTION
Related to: https://github.com/hyriver/pygeohydro/pull/111

- Added new FEMA Restful service urls.
- Changed `pygeoogc.ServiceURL.restful.fema` to `fema_nfhl`.
- updated history and authors.

 - [X] Changes and the contributor name are documented in `HISTORY.rst`.
