### PR TITLE
Fixes to ArcGISRESTful

### DIFF
--- a/src/pygeoogc/core.py
+++ b/src/pygeoogc/core.py
@@ -119,9 +119,10 @@ class ArcGISRESTfulBase:
 
     def _set_service_properties(self) -> None:
         rjson = self.get_response(self.base_url, [{"f": "json"}])[0]
+        rjson_layer = self.get_response(self.url, [{"f": "json"}])[0]
         try:
             self.valid_layers = {str(lyr["id"]): lyr["name"] for lyr in rjson["layers"]}
-            self.query_formats = rjson["supportedQueryFormats"].replace(" ", "").lower().split(",")
+            self.query_formats = rjson_layer["supportedQueryFormats"].replace(" ", "").lower().split(",")
 
             extent = rjson["extent"] if "extent" in rjson else rjson["fullExtent"]
             bounds = (extent["xmin"], extent["ymin"], extent["xmax"], extent["ymax"])
@@ -279,7 +280,7 @@ class ArcGISRESTfulBase:
                 "objectIds": ",".join(ids),
                 "returnGeometry": str(return_geom).lower(),
                 "outSR": str(self.out_sr),
-                "outfields": ",".join(self.outfields),
+                "outFields": ",".join(self.outfields),
                 "ReturnM": str(return_m).lower(),
                 "f": self.outformat,
             }


### PR DESCRIPTION
Fixed case in "outFields" parameter. Parameter "outfields" was being ignored by [map service api](https://gis.reshapewildfire.org/arcgis/help/en/rest/services-reference/enterprise/query-map-service-layer/). Polygons were being returned with one attribute ("name") instead of 25 attributes when tested with [url](https://gis.reshapewildfire.org/arcgis/rest/services/Hosted/Years_Since_Treatment/FeatureServer/0).

Added code to get "supportedQueryFormats" for the layer of interest instead of the whole feature service. Fixes issue where layer and service have different supported formats, as in [url](https://gis.reshapewildfire.org/arcgis/rest/services/Hosted/Years_Since_Treatment/FeatureServer/0)

Found these issues and tested the solution as follows:

```
import pygeoogc
import pygeoutils
twig = pygeoogc.ArcGISRESTful(
    "https://gis.reshapewildfire.org/arcgis/rest/services/Hosted/Years_Since_Treatment/FeatureServer/0", 
    crs=4326, outfields='*', outformat='geojson')
obj_ids = twig.oids_bygeom([-111.75811,35.2,-111.69317,35.35235], 4326)
resp = twig.get_features(obj_ids)
gdf = pygeoutils.json2geodf(resp)
print(len(gdf.columns))
```

Might be good to add an official test that checks for number of fields. Note, I did not setup nox or do anything in the checklist below.

<!-- Feel free to remove check-list items aren't relevant to your changes -->
 - [ ] Tests added and `nox` passes.
 - [ ] Passes `pre-commit run --all-files`
 - [ ] Changes and the contributor name are documented in `HISTORY.rst`.
